### PR TITLE
Add bulk fetching support for historical klines beyond 1000 candles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A production-ready Elixir/OTP library for cryptocurrency exchange integration wi
 ## Features
 
 - 🚀 **Real-Time Market Data**: WebSocket streaming with automatic reconnection and circuit breaker patterns
-- 📈 **Historical Data Retrieval**: REST API access to historical klines/candlestick data for backtesting
+- 📈 **Historical Data Retrieval**: REST API access to historical klines/candlestick data with bulk fetching support (>1000 candles)
 - 💼 **Secure Trading Operations**: Isolated user sessions with credential management
 - 🔄 **Phoenix.PubSub Integration**: Efficient market data distribution to multiple subscribers
 - 🛡️ **Comprehensive Error Handling**: Intelligent error classification with retry strategies
@@ -290,6 +290,35 @@ CryptoExchange.Application (Supervisor)
 - Trading operation logging
 
 ## Usage Examples
+
+### Historical Data Retrieval
+
+```elixir
+# Get last 500 1-hour candles (up to 1000 with standard function)
+{:ok, klines} = CryptoExchange.get_historical_klines("BTCUSDT", "1h", limit: 500)
+
+# Get candles for a specific date range
+{:ok, klines} = CryptoExchange.get_historical_klines("ETHUSDT", "1d",
+  start_time: 1609459200000,  # 2021-01-01
+  end_time: 1640995199000     # 2021-12-31
+)
+
+# Fetch more than 1000 candles using bulk fetching (automatic pagination)
+{:ok, klines} = CryptoExchange.get_historical_klines_bulk("BTCUSDT", "1h", limit: 5000)
+
+IO.puts("Fetched #{length(klines)} klines")
+first_kline = List.first(klines)
+last_kline = List.last(klines)
+
+# Process the klines
+Enum.each(klines, fn kline ->
+  IO.puts("Time: #{kline.open_time}, Open: #{kline.open_price}, Close: #{kline.close_price}")
+end)
+
+# Calculate statistics
+total_volume = Enum.reduce(klines, 0, fn kline, acc -> acc + kline.volume end)
+IO.puts("Total volume: #{total_volume}")
+```
 
 ### Advanced Trading Scenarios
 
@@ -653,7 +682,7 @@ For issues, questions, or contributions:
 
 - [ ] Additional exchange support (Coinbase, Kraken, etc.)
 - [ ] Advanced order types (OCO, trailing stop, etc.)
-- [ ] Historical data retrieval
+- [x] Historical data retrieval (✅ Implemented with bulk fetching support)
 - [ ] WebSocket account updates (user data streams)
 - [ ] Advanced credential encryption
 - [ ] Telemetry integration

--- a/lib/crypto_exchange.ex
+++ b/lib/crypto_exchange.ex
@@ -17,7 +17,7 @@ defmodule CryptoExchange do
   Get historical OHLC data for backtesting and analysis:
 
   ```elixir
-  # Get last 100 1-hour candles for BTC/USDT
+  # Get last 100 1-hour candles for BTC/USDT (up to 1000 candles)
   {:ok, klines} = CryptoExchange.get_historical_klines("BTCUSDT", "1h", limit: 100)
 
   # Get candles for specific date range
@@ -25,6 +25,9 @@ defmodule CryptoExchange do
     start_time: 1609459200000,  # 2021-01-01
     end_time: 1640995199000     # 2021-12-31
   )
+
+  # Fetch more than 1000 candles using bulk fetching (automatic pagination)
+  {:ok, klines} = CryptoExchange.get_historical_klines_bulk("BTCUSDT", "1h", limit: 5000)
   ```
 
   ## Real-time Data
@@ -142,6 +145,86 @@ defmodule CryptoExchange do
   def get_historical_klines(symbol, interval, opts \\ []) do
     with {:ok, client} <- PublicClient.new(),
          {:ok, klines} <- PublicClient.get_klines(client, symbol, interval, opts) do
+      {:ok, klines}
+    end
+  end
+
+  @doc """
+  Retrieves historical kline/candlestick data with support for fetching more than
+  1000 candles by making multiple paginated requests automatically.
+
+  This is similar to `get_historical_klines/3` but removes the 1000-candle limit
+  by automatically fetching data in batches when needed. Use this function when
+  you need to retrieve large amounts of historical data.
+
+  ## Parameters
+
+  - `symbol` - Trading pair symbol (e.g., "BTCUSDT", "ETHBTC")
+  - `interval` - Candlestick interval (e.g., "1m", "1h", "1d")
+    Valid intervals: "1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h",
+    "6h", "8h", "12h", "1d", "3d", "1w", "1M"
+  - `opts` - Optional parameters:
+    - `:start_time` - Start timestamp in milliseconds (inclusive)
+    - `:end_time` - End timestamp in milliseconds (inclusive)
+    - `:limit` - Number of klines to return (default: 500, no maximum)
+    - `:timezone` - Timezone for kline interpretation (default: "0" UTC)
+
+  ## Returns
+
+  - `{:ok, [%Kline{}]}` - List of kline structs on success
+  - `{:error, reason}` - Error details on failure
+
+  ## Important Notes
+
+  - For limits > 1000, multiple API calls will be made automatically
+  - Each API call counts toward Binance's rate limits (1 weight per 1000 candles)
+  - If fewer candles exist than requested, returns all available candles
+  - A small delay (100ms) is added between batches to respect rate limits
+  - Fetching stops early if a partial batch is returned (end of available data)
+
+  ## Examples
+
+  ```elixir
+  # Get 5000 1-hour candles (will make 5 API calls)
+  {:ok, klines} = CryptoExchange.get_historical_klines_bulk("BTCUSDT", "1h", limit: 5000)
+
+  # Get 2500 daily candles starting from a specific date
+  {:ok, klines} = CryptoExchange.get_historical_klines_bulk("ETHUSDT", "1d",
+    start_time: 1609459200000,  # 2021-01-01
+    limit: 2500
+  )
+
+  # Get all available 15-minute candles in a date range
+  {:ok, klines} = CryptoExchange.get_historical_klines_bulk("BTCUSDT", "15m",
+    start_time: 1609459200000,  # 2021-01-01
+    end_time: 1640995199000,    # 2021-12-31
+    limit: 50000  # Will fetch up to this many, or all available
+  )
+
+  # Process the results
+  IO.puts("Fetched \#{length(klines)} klines")
+  first_kline = List.first(klines)
+  last_kline = List.last(klines)
+  IO.puts("Date range: \#{first_kline.open_time} to \#{last_kline.close_time}")
+  ```
+
+  ## Performance Considerations
+
+  - Fetching 5000 candles takes approximately 5-6 seconds (5 requests + delays)
+  - Binance rate limit: 1200 weight per minute (can fetch ~1.2M candles/minute)
+  - For very large requests (>10,000 candles), consider saving to database incrementally
+
+  ## Rate Limiting
+
+  This function respects Binance's rate limits and includes automatic retry
+  logic with exponential backoff for rate limit errors. A 100ms delay is added
+  between batches to avoid hitting rate limits.
+  """
+  @spec get_historical_klines_bulk(String.t(), String.t(), keyword()) ::
+          {:ok, [CryptoExchange.Models.Kline.t()]} | {:error, term()}
+  def get_historical_klines_bulk(symbol, interval, opts \\ []) do
+    with {:ok, client} <- PublicClient.new(),
+         {:ok, klines} <- PublicClient.get_klines_bulk(client, symbol, interval, opts) do
       {:ok, klines}
     end
   end

--- a/lib/crypto_exchange/binance/public_client.ex
+++ b/lib/crypto_exchange/binance/public_client.ex
@@ -476,7 +476,7 @@ defmodule CryptoExchange.Binance.PublicClient do
          _opts,
          accumulated,
          remaining,
-         batch_num,
+         _batch_num,
          _batch_delay_ms
        )
        when remaining <= 0 do
@@ -524,11 +524,11 @@ defmodule CryptoExchange.Binance.PublicClient do
       Logger.debug("Limit set to 0 (end_time boundary reached), completing fetch")
       {:ok, accumulated}
     else
-      fetch_batch_request(client, symbol, interval, batch_opts, accumulated, remaining, batch_num, batch_delay_ms)
+      fetch_batch_request(client, symbol, interval, opts, batch_opts, accumulated, remaining, batch_num, batch_delay_ms, current_batch_size)
     end
   end
 
-  defp fetch_batch_request(client, symbol, interval, batch_opts, accumulated, remaining, batch_num, batch_delay_ms) do
+  defp fetch_batch_request(client, symbol, interval, opts, batch_opts, accumulated, remaining, batch_num, batch_delay_ms, current_batch_size) do
     case get_klines(client, symbol, interval, batch_opts) do
       {:ok, klines} when is_list(klines) ->
         # Prepend new klines in reverse order for O(1) performance

--- a/lib/crypto_exchange/binance/public_client.ex
+++ b/lib/crypto_exchange/binance/public_client.ex
@@ -209,7 +209,9 @@ defmodule CryptoExchange.Binance.PublicClient do
     - `:start_time` - Start time in milliseconds (inclusive)
     - `:end_time` - End time in milliseconds (inclusive)
     - `:timezone` - Timezone for kline interpretation (default: "0" UTC)
-    - `:limit` - Number of klines to return (default: 500, no maximum)
+    - `:limit` - Number of klines to return (default: 500, max: 100000)
+    - `:batch_delay_ms` - Delay between batch requests in milliseconds (default: 100)
+    - `:return_partial_on_error` - Return partial results if an error occurs mid-fetch (default: false)
 
   ## Returns
   - `{:ok, [%Kline{}]}` - List of parsed kline structs on success
@@ -221,6 +223,7 @@ defmodule CryptoExchange.Binance.PublicClient do
   - If fewer candles exist than requested, returns all available candles
   - Fetching stops early if a partial batch is returned (end of available data)
   - Be mindful of rate limits when requesting large amounts of data
+  - Maximum limit is capped at 100,000 candles to prevent excessive API usage
 
   ## Examples
   ```elixir
@@ -239,6 +242,18 @@ defmodule CryptoExchange.Binance.PublicClient do
     end_time: 1640995199000,
     limit: 50000  # Will fetch up to this many, or all available
   )
+
+  # Customize batch delay for rate limit management
+  {:ok, klines} = PublicClient.get_klines_bulk(client, "BTCUSDT", "1h",
+    limit: 5000,
+    batch_delay_ms: 200  # 200ms between batches
+  )
+
+  # Return partial results on error (useful for long-running fetches)
+  {:ok, klines} = PublicClient.get_klines_bulk(client, "BTCUSDT", "1h",
+    limit: 50000,
+    return_partial_on_error: true  # Returns data fetched before error
+  )
   ```
   """
   def get_klines_bulk(%__MODULE__{} = client, symbol, interval, opts \\ []) do
@@ -256,7 +271,8 @@ defmodule CryptoExchange.Binance.PublicClient do
       with :ok <- validate_symbol(symbol),
            :ok <- validate_interval(interval),
            :ok <- validate_bulk_limit(requested_limit) do
-        fetch_klines_in_batches(client, symbol, interval, opts, requested_limit)
+        batch_delay_ms = Keyword.get(opts, :batch_delay_ms, 100)
+        fetch_klines_in_batches(client, symbol, interval, opts, requested_limit, batch_delay_ms)
       else
         {:error, reason} = error ->
           Logger.error("Failed to get klines bulk: #{inspect(reason)}")
@@ -425,27 +441,50 @@ defmodule CryptoExchange.Binance.PublicClient do
     {:error, {:invalid_limit, "Limit must be between 1 and 1000, got: #{inspect(limit)}"}}
   end
 
-  defp validate_bulk_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+  defp validate_bulk_limit(limit) when is_integer(limit) and limit > 0 and limit <= 100_000,
+    do: :ok
+
+  defp validate_bulk_limit(limit) when is_integer(limit) and limit > 100_000 do
+    {:error,
+     {:invalid_limit,
+      "Bulk limit must not exceed 100,000 candles (got: #{limit}). This protects against excessive API usage."}}
+  end
 
   defp validate_bulk_limit(limit) do
     {:error, {:invalid_limit, "Bulk limit must be a positive integer, got: #{inspect(limit)}"}}
   end
 
   # Batch fetching logic for getting more than 1000 klines
-  defp fetch_klines_in_batches(client, symbol, interval, opts, total_limit) do
-    Logger.debug("Fetching #{total_limit} klines in batches of 1000")
+  defp fetch_klines_in_batches(client, symbol, interval, opts, total_limit, batch_delay_ms) do
+    Logger.debug("Fetching #{total_limit} klines in batches of 1000 (delay: #{batch_delay_ms}ms)")
 
-    # Start fetching with empty accumulator
-    fetch_batch(client, symbol, interval, opts, [], total_limit, 0)
+    # Start fetching with empty accumulator (will be built in reverse)
+    case fetch_batch(client, symbol, interval, opts, [], total_limit, 0, batch_delay_ms) do
+      {:ok, reversed_klines} ->
+        # Reverse the accumulated list to get correct chronological order
+        {:ok, Enum.reverse(reversed_klines)}
+
+      error ->
+        error
+    end
   end
 
-  defp fetch_batch(_client, _symbol, _interval, _opts, accumulated, remaining, batch_num)
+  defp fetch_batch(
+         _client,
+         _symbol,
+         _interval,
+         _opts,
+         accumulated,
+         remaining,
+         batch_num,
+         _batch_delay_ms
+       )
        when remaining <= 0 do
     Logger.debug("Completed fetching all requested klines. Total: #{length(accumulated)}")
     {:ok, accumulated}
   end
 
-  defp fetch_batch(client, symbol, interval, opts, accumulated, remaining, batch_num) do
+  defp fetch_batch(client, symbol, interval, opts, accumulated, remaining, batch_num, batch_delay_ms) do
     current_batch_size = min(remaining, 1000)
     batch_opts = Keyword.put(opts, :limit, current_batch_size)
 
@@ -456,19 +495,45 @@ defmodule CryptoExchange.Binance.PublicClient do
           # First batch - use original start_time if provided
           batch_opts
 
-        %Kline{close_time: last_close_time} ->
+        %Kline{kline_close_time: last_close_time} ->
           # Subsequent batch - start from the millisecond after the last kline's close time
           # This ensures no gaps or duplicates
-          Keyword.put(batch_opts, :start_time, last_close_time + 1)
+          new_start_time = last_close_time + 1
+
+          # Check if we've exceeded end_time boundary (if provided)
+          case Keyword.get(opts, :end_time) do
+            nil ->
+              Keyword.put(batch_opts, :start_time, new_start_time)
+
+            end_time when new_start_time > end_time ->
+              # We've reached the end_time boundary, stop fetching
+              Logger.debug("Reached end_time boundary (#{end_time}), stopping batch fetch")
+              Keyword.put(batch_opts, :limit, 0)
+
+            _end_time ->
+              Keyword.put(batch_opts, :start_time, new_start_time)
+          end
       end
 
     Logger.debug(
       "Fetching batch #{batch_num + 1}, requesting #{current_batch_size} klines (#{length(accumulated)} accumulated so far)"
     )
 
+    # Check if limit was set to 0 (end_time boundary reached)
+    if Keyword.get(batch_opts, :limit, current_batch_size) == 0 do
+      Logger.debug("Limit set to 0 (end_time boundary reached), completing fetch")
+      {:ok, accumulated}
+    else
+      fetch_batch_request(client, symbol, interval, batch_opts, accumulated, remaining, batch_num, batch_delay_ms)
+    end
+  end
+
+  defp fetch_batch_request(client, symbol, interval, batch_opts, accumulated, remaining, batch_num, batch_delay_ms) do
     case get_klines(client, symbol, interval, batch_opts) do
       {:ok, klines} when is_list(klines) ->
-        new_accumulated = accumulated ++ klines
+        # Prepend new klines in reverse order for O(1) performance
+        # The final list will be reversed at the end to restore chronological order
+        new_accumulated = Enum.reverse(klines) ++ accumulated
         fetched_count = length(klines)
 
         Logger.debug("Batch #{batch_num + 1} returned #{fetched_count} klines")
@@ -492,9 +557,9 @@ defmodule CryptoExchange.Binance.PublicClient do
           true ->
             new_remaining = remaining - fetched_count
 
-            # Small delay to respect rate limits (optional, can be configured)
-            if new_remaining > 0 do
-              Process.sleep(100)
+            # Small delay to respect rate limits (configurable via batch_delay_ms)
+            if new_remaining > 0 and batch_delay_ms > 0 do
+              Process.sleep(batch_delay_ms)
             end
 
             fetch_batch(
@@ -504,21 +569,38 @@ defmodule CryptoExchange.Binance.PublicClient do
               opts,
               new_accumulated,
               new_remaining,
-              batch_num + 1
+              batch_num + 1,
+              batch_delay_ms
             )
         end
 
       {:error, reason} = error ->
         # On error, log how many klines we successfully fetched before the error
-        if length(accumulated) > 0 do
+        accumulated_count = length(accumulated)
+
+        if accumulated_count > 0 do
           Logger.error(
-            "Error fetching batch #{batch_num + 1} after successfully fetching #{length(accumulated)} klines: #{inspect(reason)}"
+            "Error fetching batch #{batch_num + 1} after successfully fetching #{accumulated_count} klines: #{inspect(reason)}"
           )
+
+          # Check if return_partial option is enabled
+          if Keyword.get(opts, :return_partial_on_error, false) do
+            Logger.info(
+              "Returning #{accumulated_count} partial klines due to return_partial_on_error option"
+            )
+
+            {:ok, accumulated}
+          else
+            Logger.warning(
+              "Discarding #{accumulated_count} klines. Set return_partial_on_error: true to return partial results on error."
+            )
+
+            error
+          end
         else
           Logger.error("Error fetching first batch: #{inspect(reason)}")
+          error
         end
-
-        error
     end
   end
 

--- a/lib/crypto_exchange/binance/public_client.ex
+++ b/lib/crypto_exchange/binance/public_client.ex
@@ -484,7 +484,16 @@ defmodule CryptoExchange.Binance.PublicClient do
     {:ok, accumulated}
   end
 
-  defp fetch_batch(client, symbol, interval, opts, accumulated, remaining, batch_num, batch_delay_ms) do
+  defp fetch_batch(
+         client,
+         symbol,
+         interval,
+         opts,
+         accumulated,
+         remaining,
+         batch_num,
+         batch_delay_ms
+       ) do
     current_batch_size = min(remaining, 1000)
     batch_opts = Keyword.put(opts, :limit, current_batch_size)
 
@@ -524,11 +533,33 @@ defmodule CryptoExchange.Binance.PublicClient do
       Logger.debug("Limit set to 0 (end_time boundary reached), completing fetch")
       {:ok, accumulated}
     else
-      fetch_batch_request(client, symbol, interval, opts, batch_opts, accumulated, remaining, batch_num, batch_delay_ms, current_batch_size)
+      fetch_batch_request(
+        client,
+        symbol,
+        interval,
+        opts,
+        batch_opts,
+        accumulated,
+        remaining,
+        batch_num,
+        batch_delay_ms,
+        current_batch_size
+      )
     end
   end
 
-  defp fetch_batch_request(client, symbol, interval, opts, batch_opts, accumulated, remaining, batch_num, batch_delay_ms, current_batch_size) do
+  defp fetch_batch_request(
+         client,
+         symbol,
+         interval,
+         opts,
+         batch_opts,
+         accumulated,
+         remaining,
+         batch_num,
+         batch_delay_ms,
+         current_batch_size
+       ) do
     case get_klines(client, symbol, interval, batch_opts) do
       {:ok, klines} when is_list(klines) ->
         # Prepend new klines in reverse order for O(1) performance


### PR DESCRIPTION
## Summary

This PR adds support for fetching more than 1000 historical klines/candles by implementing automatic pagination. The new functionality is provided through a new `get_klines_bulk/4` function that transparently handles multiple API requests when needed.

### Changes

- **New function**: `CryptoExchange.Binance.PublicClient.get_klines_bulk/4` - Core implementation with automatic pagination
- **Public API wrapper**: `CryptoExchange.get_historical_klines_bulk/3` - Convenient public interface
- **Helper functions**: `validate_bulk_limit/1`, `fetch_klines_in_batches/4`, `fetch_batch/7` - Batch fetching logic
- **Documentation**: Comprehensive function documentation with usage examples
- **README updates**: Added usage examples and updated features list

### How It Works

1. **Smart batching**: Splits large requests into chunks of 1000 candles (Binance API limit)
2. **Sequential fetching**: Uses the last kline's `close_time` + 1ms as the start time for the next batch
3. **Rate limit protection**: Adds 100ms delay between batches to respect Binance rate limits
4. **Early termination**: Stops fetching when a partial batch is received (end of available data)
5. **Error handling**: Comprehensive logging and graceful error handling

### Features

✅ No breaking changes - new function added alongside existing `get_historical_klines/3`
✅ Automatic fallback to single request for limit ≤ 1000
✅ Rate limit aware with configurable delays
✅ Comprehensive debug logging for troubleshooting
✅ Well documented with examples
✅ Error resilient with detailed error reporting

### Usage Examples

```elixir
# Fetch 5000 1-hour candles (makes 5 API calls)
{:ok, klines} = CryptoExchange.get_historical_klines_bulk("BTCUSDT", "1h", limit: 5000)

# Fetch 2500 daily candles with start time
{:ok, klines} = CryptoExchange.get_historical_klines_bulk("ETHUSDT", "1d",
  start_time: 1609459200000,  # 2021-01-01
  limit: 2500
)

# Fetch all available candles in a date range
{:ok, klines} = CryptoExchange.get_historical_klines_bulk("BTCUSDT", "15m",
  start_time: 1609459200000,
  end_time: 1640995199000,
  limit: 50000
)